### PR TITLE
[proposal] allow for rotated node labels

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Nora Kassner <nora.kassner@t-online.de>
+* Christian Diener <mail (at) cdiener.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.3.7 (2018-XX-XX)
+------------------
+
+* Node labels in CircosPlot can now be rotated with the `rotate_labels`
+  argument.
+
 0.3.6 (2018-02-20)
 ------------------
 

--- a/examples/circos/rotate_labels.py
+++ b/examples/circos/rotate_labels.py
@@ -1,0 +1,22 @@
+"""
+Shows how to rotate node labels. This increaes legibility for longer labels.
+"""
+
+import matplotlib.pyplot as plt
+import networkx as nx
+
+from nxviz.plots import CircosPlot
+
+G = nx.barbell_graph(m1=20, m2=3)
+# let's give the nodes some longer labels
+G = nx.relabel_nodes(G,
+                     {i: "long name #" + str(i) for i in range(len(G))}
+                     )
+
+# try it `rotate_labels=False` to see how the long names overlap each other
+c = CircosPlot(G, node_labels=True, rotate_labels=True)
+c.draw()
+# the rotated labels take up more space, so we will have to increase the
+# padding a bit. 15% on all sides works well here.
+plt.tight_layout(rect=(0.15, 0.15, 0.85, 0.85))
+plt.show()

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -7,9 +7,9 @@ import networkx as nx
 from matplotlib.cm import get_cmap
 from matplotlib.path import Path
 
-import numpy as np
 
 from .geometry import circos_radius, get_cartesian, node_theta
+from .polcart import to_degrees
 from .utils import (cmaps, infer_data_type, is_data_diverging,
                     num_discrete_groups)
 
@@ -324,6 +324,11 @@ class CircosPlot(BasePlot):
 
         This method is always called after the compute_node_positions
         method, so that the plot_radius is pre-computed.
+
+        This will also add a new attribute, `node_label_rotation` to the object
+        which contains the rotation angles for each of the nodes. Together with
+        the node coordinates this can be used to add additional annotations
+        with rotated text.
         """
         xs = []
         ys = []
@@ -332,7 +337,7 @@ class CircosPlot(BasePlot):
         rotations = []
         for node in self.nodes:
             theta = node_theta(self.nodes, node)
-            radius = 1.01 * (self.plot_radius + self.nodeprops['radius'])
+            radius = 1.02 * (self.plot_radius + self.nodeprops['radius'])
 
             x, y = get_cartesian(r=radius, theta=theta)
 
@@ -353,10 +358,11 @@ class CircosPlot(BasePlot):
             if self.rotate:
                 va = "center"
             # Computes the text rotation
-            if theta >= -np.pi / 2 and theta < np.pi / 2:   # left side
-                rot = theta / np.pi * 180
-            else:  # right side
-                rot = theta / np.pi * 180 - 180
+            theta_deg = to_degrees(theta)
+            if theta_deg >= -90 and theta_deg < 90:   # right side
+                rot = theta_deg
+            else:  # left side
+                rot = theta_deg - 180
 
             xs.append(x)
             ys.append(y)

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -7,6 +7,8 @@ import networkx as nx
 from matplotlib.cm import get_cmap
 from matplotlib.path import Path
 
+import numpy as np
+
 from .geometry import circos_radius, get_cartesian, node_theta
 from .utils import (cmaps, infer_data_type, is_data_diverging,
                     num_discrete_groups)
@@ -286,6 +288,17 @@ class CircosPlot(BasePlot):
     """
     Plotting object for CircosPlot.
     """
+    def __init__(self, graph, **kwargs):
+        """Create the CircosPlot.
+
+        Accepts the following additional arguments apart from the ones in
+        `BasePlot`:
+
+        :param rotate_labels: Whether to rotate node labels.
+        :type node_color: `bool`
+        """
+        self.rotate = kwargs.pop("rotate_labels", False)
+        super(CircosPlot, self).__init__(graph, **kwargs)
 
     def compute_node_positions(self):
         """
@@ -316,9 +329,10 @@ class CircosPlot(BasePlot):
         ys = []
         has = []
         vas = []
+        rotations = []
         for node in self.nodes:
             theta = node_theta(self.nodes, node)
-            radius = self.plot_radius + self.nodeprops['radius']
+            radius = 1.01 * (self.plot_radius + self.nodeprops['radius'])
 
             x, y = get_cartesian(r=radius, theta=theta)
 
@@ -330,17 +344,28 @@ class CircosPlot(BasePlot):
             else:
                 ha = 'right'
             if y == 0:
-                va = 'middle'
+                va = 'center'
             elif y > 0:
                 va = 'bottom'
             else:
                 va = 'top'
+
+            if self.rotate:
+                va = "center"
+            # Computes the text rotation
+            if theta >= -np.pi / 2 and theta < np.pi / 2:   # left side
+                rot = theta / np.pi * 180
+            else:  # right side
+                rot = theta / np.pi * 180 - 180
+
             xs.append(x)
             ys.append(y)
             has.append(ha)
             vas.append(va)
+            rotations.append(rot)
         self.node_label_coords = {'x': xs, 'y': ys}  # node label coordinates
         self.node_label_aligns = {'has': has, 'vas': vas}  # node label alignments  # noqa
+        self.node_label_rotation = rotations
 
     def draw_nodes(self):
         """
@@ -361,9 +386,13 @@ class CircosPlot(BasePlot):
                 label_y = self.node_label_coords['y'][i]
                 label_ha = self.node_label_aligns['has'][i]
                 label_va = self.node_label_aligns['vas'][i]
+                rot = 0
+                if self.rotate:
+                    rot = self.node_label_rotation[i]
                 self.ax.text(s=node,
                              x=label_x, y=label_y,
-                             ha=label_ha, va=label_va)
+                             ha=label_ha, va=label_va, rotation=rot,
+                             rotation_mode="anchor")
 
     def draw_edges(self):
         """


### PR DESCRIPTION
This adds an option to `CircosPlot` that allows for node labels to be rotated in the direction of their edges (argument `rotate_labels`). For instance:

![circos](https://user-images.githubusercontent.com/7153935/37548186-cc083778-293b-11e8-9dbf-01c5b20a30bb.png)

This improves the legibility of the labels in some cases. 

This PR also fixes a small issue with vertical alignments which were set to `middle` before which is now called `center` in newer versions of matplotlib.