### PR TITLE
ArcPlot and CircosPlot with edge_width, pass dict key or list

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Contributors
 * Christian Diener <mail (at) cdiener.com>
 * Thijs Hermans <hermansthijs91@gmail.com>
 * R. M. Keelan Downton <keelan.downton@gmail.com>
+* Maximilian T. Strauss <straussmaximilian (at) gmail.com>

--- a/examples/arc/edge_width.py
+++ b/examples/arc/edge_width.py
@@ -1,0 +1,39 @@
+
+"""
+Displays different edge_widths with ArcPlot, see also Issue #291
+"""
+
+import matplotlib.pyplot as plt
+import networkx as nx
+from nxviz.plots import ArcPlot
+
+G = nx.DiGraph()
+
+NODES_EBUNCH = [
+    ('A', {'n_visitors': '1'}),
+    ('B', {'n_visitors': '3'}),
+    ('C', {'n_visitors': '4'}),
+]
+
+G.add_nodes_from(NODES_EBUNCH)
+
+EDGES_EBUNCH = [
+    ('A', 'B', 1),
+    ('A', 'C', 2),
+    ('B', 'C', 25),
+    ('C', 'B', 10),
+]
+
+G.add_weighted_edges_from(
+    EDGES_EBUNCH,
+)
+
+edges = G.edges()
+
+c = ArcPlot(G, node_labels=True,
+                     node_size='n_visitors',
+                     node_color='n_visitors',
+                     edge_width='weight')
+
+c.draw()
+plt.show()

--- a/examples/arc/edge_width.py
+++ b/examples/arc/edge_width.py
@@ -31,9 +31,9 @@ G.add_weighted_edges_from(
 edges = G.edges()
 
 c = ArcPlot(G, node_labels=True,
-                     node_size='n_visitors',
-                     node_color='n_visitors',
-                     edge_width='weight')
+            node_size='n_visitors',
+            node_color='n_visitors',
+            edge_width='weight')
 
 c.draw()
 plt.show()

--- a/examples/circos/edge_width.py
+++ b/examples/circos/edge_width.py
@@ -11,7 +11,7 @@ edgelist1 = [
     ("b", "c"),
     ("c", "d"),
     ("d", "e"),
-    ("e", "f"),]
+    ("e", "f")]
 
 weights = list(range(6))
 

--- a/examples/circos/edge_width.py
+++ b/examples/circos/edge_width.py
@@ -1,0 +1,24 @@
+"""
+Shows different edge widths on CircusPlot
+"""
+import matplotlib.pyplot as plt
+import networkx as nx
+from nxviz.plots import CircosPlot
+
+nodelist = [("a"), ("b"), ("c"), ("d"), ("e"), ("f")]
+edgelist1 = [
+    ("a", "b"),
+    ("b", "c"),
+    ("c", "d"),
+    ("d", "e"),
+    ("e", "f"),]
+
+weights = list(range(6))
+
+G = nx.Graph()
+G.add_nodes_from(nodelist)
+G.add_edges_from(edgelist1)
+c = CircosPlot(graph=G, edge_width=weights)
+c.draw()
+
+plt.show()

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -310,10 +310,10 @@ class BasePlot(object):
     def compute_edge_widths(self):
         """Compute the edge widths."""
         if type(self.edge_width) is str:
-            self.edge_widths = [self.graph.edges[n][self.edge_width] for n in self.edges]
+            edges = self.graph.edges
+            self.edge_widths = [edges[n][self.edge_width] for n in self.edges]
         else:
             self.edge_widths = self.edge_width
-
 
     def compute_group_label_positions(self):
         """Computes the position of each group label according to the wanted

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -130,6 +130,12 @@ class BasePlot(object):
 
         # Set edge properties
         self.edge_width = edge_width
+        if self.edge_width:
+            self.edge_widths = []
+            self.compute_edge_widths()
+        else:
+            self.edge_widths = [1] * len(self.edges)
+
         self.edge_color = edge_color
         if self.edge_color:
             self.edge_colors = []
@@ -300,6 +306,14 @@ class BasePlot(object):
                 ),
             )
             self.sm._A = []
+
+    def compute_edge_widths(self):
+        """Compute the edge widths."""
+        if type(self.edge_width) is str:
+            self.edge_widths = [self.graph.edges[n][self.edge_width] for n in self.edges]
+        else:
+            self.edge_widths = self.edge_width
+
 
     def compute_group_label_positions(self):
         """Computes the position of each group label according to the wanted
@@ -731,9 +745,10 @@ class CircosPlot(BasePlot):
             ]
             color = self.edge_colors[i]
             codes = [Path.MOVETO, Path.CURVE3, Path.CURVE3]
+            lw = self.edge_widths[i]
             path = Path(verts, codes)
             patch = patches.PathPatch(
-                path, lw=1, edgecolor=color, zorder=1, **self.edgeprops
+                path, lw=lw, edgecolor=color, zorder=1, **self.edgeprops
             )
             self.ax.add_patch(patch)
 
@@ -1009,9 +1024,9 @@ class ArcPlot(BasePlot):
             verts = [(start_x, start_y), (middle_x, middle_y), (end_x, end_y)]
 
             codes = [Path.MOVETO, Path.CURVE3, Path.CURVE3]
-
+            lw = self.edge_widths[i]
             path = Path(verts, codes)
-            patch = patches.PathPatch(path, lw=1, zorder=1, **self.edgeprops)
+            patch = patches.PathPatch(path, lw=lw, zorder=1, **self.edgeprops)
             self.ax.add_patch(patch)
 
     def draw(self):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -41,3 +41,22 @@ def test_geo_plot():
 
 def test_plot_size():
     c = CircosPlot(G, figsize=(3, 3))  # noqa: F841
+
+
+def test_edge_widths():
+    # add weight as attribute and fill with random numbers
+    edges = G.edges()
+    for u, v in edges:
+        G[u][v]['weight'] = random()
+    # also extract list for testing
+    weights = [G[u][v]['weight'] for u, v in edges]
+    # add weights as proptery
+    c = CircosPlot(G, edge_width="weight")
+    assert(c.edge_widths == weights)
+    a = ArcPlot(G, edge_width="weight")
+    assert(a.edge_widths == weights)
+    # add weights as list
+    c = CircosPlot(G, edge_width=weights)
+    assert(c.edge_widths == weights)
+    a = ArcPlot(G, edge_width=weights)
+    assert(a.edge_widths == weights)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -52,11 +52,11 @@ def test_edge_widths():
     weights = [G[u][v]['weight'] for u, v in edges]
     # add weights as proptery
     c = CircosPlot(G, edge_width="weight")
-    assert(c.edge_widths == weights)
+    assert c.edge_widths == weights
     a = ArcPlot(G, edge_width="weight")
-    assert(a.edge_widths == weights)
+    assert a.edge_widths == weights
     # add weights as list
     c = CircosPlot(G, edge_width=weights)
-    assert(c.edge_widths == weights)
+    assert c.edge_widths == weights
     a = ArcPlot(G, edge_width=weights)
-    assert(a.edge_widths == weights)
+    assert a.edge_widths == weights


### PR DESCRIPTION
Hi,
I like your package and wanted to use edge_widths with ArcPlot and CircosPlot and saw issue #291. I noticed that people either hand over the attribute name of the edges or a list (e.g., https://stackoverflow.com/questions/25639169/networkx-change-color-width-according-to-edge-attributes-inconsistent-result). Extended the function similar to the edge_colors implementation.

![figure_01](https://user-images.githubusercontent.com/16521288/46321087-b3397200-c5e1-11e8-9814-d646a93d4452.png)

![figure_02](https://user-images.githubusercontent.com/16521288/46321088-b3397200-c5e1-11e8-8cee-751057301058.png)

