### PR TITLE
Remove Python=3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ language: python
 matrix:
   include:
     - python: 3.5  # we don't actually use this
-      env: PYTHON_VERSION=3.5
-
-    - python: 3.5  # we don't actually use this
       env: PYTHON_VERSION=3.6
 
     - python: 3.5  # we don't actually use this


### PR DESCRIPTION
Done in accordance with supporting only the latest two versions of Python.