### PR TITLE
ArcPlot nodesize and edgecolor

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors
 - Maximilian T. Strauss <straussmaximilian (at) gmail.com>
 - Brian Cajes @bcajes
 - Ashutosh Chandra @ashu16993
+- Rabeez Riaz <19100165 (at) lums.edu.pk>

--- a/examples/arc/edge_color.py
+++ b/examples/arc/edge_color.py
@@ -8,19 +8,14 @@ from nxviz.plots import ArcPlot
 
 G = nx.DiGraph()
 
-NODES_EBUNCH = [
-    ("A", {"n_visitors": "1"}),
-    ("B", {"n_visitors": "3"}),
-    ("C", {"n_visitors": "4"}),
-]
-
-G.add_nodes_from(NODES_EBUNCH)
+G.add_node("A")
+G.add_node("B")
+G.add_node("C")
 
 
 G.add_edge("A", "B", weight=8, type="a")
 G.add_edge("A", "C", weight=8, type="b")
 G.add_edge("B", "C", weight=8, type="a")
-G.add_edge("C", "B", weight=8, type="b")
 
 
 edges = G.edges()

--- a/examples/arc/edge_color.py
+++ b/examples/arc/edge_color.py
@@ -17,19 +17,16 @@ NODES_EBUNCH = [
 G.add_nodes_from(NODES_EBUNCH)
 
 
-G.add_edge("A", "B", weight=5, type="a")
-G.add_edge("A", "C", weight=5, type="b")
-G.add_edge("B", "C", weight=5, type="a")
-G.add_edge("C", "B", weight=5, type="b")
+G.add_edge("A", "B", weight=8, type="a")
+G.add_edge("A", "C", weight=8, type="b")
+G.add_edge("B", "C", weight=8, type="a")
+G.add_edge("C", "B", weight=8, type="b")
 
 
 edges = G.edges()
 
 c = ArcPlot(
     G,
-    node_labels=True,
-    node_size="n_visitors",
-    node_color="n_visitors",
     edge_width="weight",
     edge_color="type"
 )

--- a/examples/arc/edge_color.py
+++ b/examples/arc/edge_color.py
@@ -1,0 +1,38 @@
+"""
+Displays different edge_colors with ArcPlot
+"""
+
+import matplotlib.pyplot as plt
+import networkx as nx
+from nxviz.plots import ArcPlot
+
+G = nx.DiGraph()
+
+NODES_EBUNCH = [
+    ("A", {"n_visitors": "1"}),
+    ("B", {"n_visitors": "3"}),
+    ("C", {"n_visitors": "4"}),
+]
+
+G.add_nodes_from(NODES_EBUNCH)
+
+
+G.add_edge("A", "B", weight=5, type="a")
+G.add_edge("A", "C", weight=5, type="b")
+G.add_edge("B", "C", weight=5, type="a")
+G.add_edge("C", "B", weight=5, type="b")
+
+
+edges = G.edges()
+
+c = ArcPlot(
+    G,
+    node_labels=True,
+    node_size="n_visitors",
+    node_color="n_visitors",
+    edge_width="weight",
+    edge_color="type"
+)
+
+c.draw()
+plt.show()

--- a/examples/arc/edge_color.py
+++ b/examples/arc/edge_color.py
@@ -6,19 +6,12 @@ import matplotlib.pyplot as plt
 import networkx as nx
 from nxviz.plots import ArcPlot
 
-G = nx.DiGraph()
-
-G.add_node("A")
-G.add_node("B")
-G.add_node("C")
-
+G = nx.Graph()
 
 G.add_edge("A", "B", weight=8, type="a")
 G.add_edge("A", "C", weight=8, type="b")
 G.add_edge("B", "C", weight=8, type="a")
 
-
-edges = G.edges()
 
 c = ArcPlot(
     G,

--- a/examples/arc/node_size.py
+++ b/examples/arc/node_size.py
@@ -1,0 +1,29 @@
+"""
+Displays different node_size with ArcPlot
+"""
+
+import matplotlib.pyplot as plt
+import networkx as nx
+from nxviz.plots import ArcPlot
+
+G = nx.Graph()
+
+G.add_node("A", score=1.5)
+G.add_node("B", score=0.5)
+G.add_node("C", score=1)
+
+
+G.add_edge("A", "B", weight=8, type="a")
+G.add_edge("A", "C", weight=8, type="b")
+G.add_edge("B", "C", weight=8, type="a")
+
+
+c = ArcPlot(
+    G,
+    node_size='score',
+    edge_width="weight",
+    edge_color="type"
+)
+
+c.draw()
+plt.show()

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -134,6 +134,11 @@ class BasePlot(object):
 
         # Set node radius
         self.node_size = node_size
+        if self.node_size:
+            self.node_sizes = []
+            self.compute_node_sizes()
+        else:
+            self.node_sizes = [1] * len(self.nodes)
 
         # Set node colors
         self.node_color = node_color
@@ -333,6 +338,14 @@ class BasePlot(object):
                 ),
             )
             self.sm._A = []
+
+    def compute_node_sizes(self):
+        """Compute the node sizes."""
+        if type(self.node_size) is str:
+            nodes = self.graph.nodes
+            self.node_sizes = [nodes[n][self.node_size] for n in self.nodes]
+        else:
+            self.node_sizes = self.node_size
 
     def compute_edge_widths(self):
         """Compute the edge widths."""
@@ -1013,12 +1026,10 @@ class ArcPlot(BasePlot):
         assumed to be equal to 0.5 units. Nodes are placed at integer
         locations.
         """
-        xs = []
-        ys = []
-
-        for node in self.nodes:
-            xs.append(self.nodes.index(node))
-            ys.append(0)
+        xs = [0] * len(self.nodes)
+        ys = [0] * len(self.nodes)
+        for i,_ in enumerate(self.nodes[1:], start=1):
+            xs[i] = xs[i-1] + (self.node_sizes[i-1] / 2) + (self.node_sizes[i] / 2)
 
         self.node_coords = {"x": xs, "y": ys}
 
@@ -1026,13 +1037,13 @@ class ArcPlot(BasePlot):
         """
         Draw nodes to screen.
         """
-        node_r = 1
+        node_r = self.node_sizes
         for i, node in enumerate(self.nodes):
             x = self.node_coords["x"][i]
             y = self.node_coords["y"][i]
             color = self.node_colors[i]
             node_patch = patches.Ellipse(
-                (x, y), node_r, node_r, lw=0, color=color, zorder=2
+                (x, y), node_r[i], node_r[i], lw=0, color=color, zorder=2
             )
             self.ax.add_patch(node_patch)
 

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -1028,8 +1028,10 @@ class ArcPlot(BasePlot):
         """
         xs = [0] * len(self.nodes)
         ys = [0] * len(self.nodes)
-        for i,_ in enumerate(self.nodes[1:], start=1):
-            xs[i] = xs[i-1] + (self.node_sizes[i-1] / 2) + (self.node_sizes[i] / 2)
+        for i, _ in enumerate(self.nodes[1:], start=1):
+            prev_r = self.node_sizes[i-1] / 2
+            curr_r = self.node_sizes[i] / 2
+            xs[i] = xs[i-1] + prev_r + curr_r
 
         self.node_coords = {"x": xs, "y": ys}
 
@@ -1072,7 +1074,9 @@ class ArcPlot(BasePlot):
             codes = [Path.MOVETO, Path.CURVE3, Path.CURVE3]
             lw = self.edge_widths[i]
             path = Path(verts, codes)
-            patch = patches.PathPatch(path, lw=lw, edgecolor=color, zorder=1, **self.edgeprops)
+            patch = patches.PathPatch(
+                path, lw=lw, edgecolor=color, zorder=1, **self.edgeprops
+            )
             self.ax.add_patch(patch)
 
     def draw(self):

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -1057,10 +1057,11 @@ class ArcPlot(BasePlot):
 
             verts = [(start_x, start_y), (middle_x, middle_y), (end_x, end_y)]
 
+            color = self.edge_colors[i]
             codes = [Path.MOVETO, Path.CURVE3, Path.CURVE3]
             lw = self.edge_widths[i]
             path = Path(verts, codes)
-            patch = patches.PathPatch(path, lw=lw, zorder=1, **self.edgeprops)
+            patch = patches.PathPatch(path, lw=lw, edgecolor=color, zorder=1, **self.edgeprops)
             self.ax.add_patch(patch)
 
     def draw(self):


### PR DESCRIPTION
I ran across issue #291 while trying to make a short network analysis example on a Game of Thrones dataset to celebrate the final season. I thought I'd take a crack at it fixing it. 

I have added the following things in ArcPlot:
- The `edge_color` option now works when supplied with an attribute name for the edges.
<img src="https://user-images.githubusercontent.com/9392057/55905625-ce69e780-5beb-11e9-82d4-e4f3a9722f0e.png" alt="drawing" width="400"/>
- The  `node_size` option now works when supplied with an attribute name for the nodes.
<img src="https://user-images.githubusercontent.com/9392057/55905646-daee4000-5beb-11e9-9f67-34a1668d8ff2.png" alt="drawing" width="400"/>
- One example script for each change each (the screenshots ^).

</br>
</br>
I ran across a few issues when running the tests (both `flake8` and `py.test`). Could anyone help me figure those out?

@ericmjl
