### PR TITLE
Corrected alignment for node labels

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,3 +18,4 @@ Contributors
 - Brian Cajes @bcajes
 - Ashutosh Chandra @ashu16993
 - Rabeez Riaz <19100165 (at) lums.edu.pk>
+- Erick Armingol <earmingol (at) eng.ucsd.edu>

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -614,7 +614,7 @@ class CircosPlot(BasePlot):
 
             # Coordinates of text inside nodes
             if self.node_label_layout == "numbers":
-                radius_adjustment = 1.0 - (1.0 / radius)
+                radius_adjustment = self.plot_radius / radius
             else:
                 radius_adjustment = 1.02
             x, y = get_cartesian(r=radius * radius_adjustment, theta=theta)
@@ -641,11 +641,10 @@ class CircosPlot(BasePlot):
 
             # Computes the text rotation
             theta_deg = to_degrees(theta)
-            if theta_deg >= -90 and theta_deg < 90:  # right side
+            if theta_deg >= -90 and theta_deg <= 90:  # right side
                 rot = theta_deg
             else:  # left side
                 rot = theta_deg - 180
-
             # Store values
             self.store_node_label_meta(x, y, tx, ty, rot)
 
@@ -704,7 +703,7 @@ class CircosPlot(BasePlot):
             self.node_label_aligns["has"].append("right")
 
         # Computes the text alignment for y
-        if self.node_label_layout == "rotate" or y == 0:
+        if self.node_label_layout == "rotation" or y == 0:
             self.node_label_aligns["vas"].append("center")
         elif y > 0:
             self.node_label_aligns["vas"].append("bottom")

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -614,7 +614,7 @@ class CircosPlot(BasePlot):
 
             # Coordinates of text inside nodes
             if self.node_label_layout == "numbers":
-                radius_adjustment = self.plot_radius / radius
+                radius_adjustment = 1.0 - (1.0 / radius)
             else:
                 radius_adjustment = 1.02
             x, y = get_cartesian(r=radius * radius_adjustment, theta=theta)
@@ -641,10 +641,11 @@ class CircosPlot(BasePlot):
 
             # Computes the text rotation
             theta_deg = to_degrees(theta)
-            if theta_deg >= -90 and theta_deg <= 90:  # right side
+            if theta_deg >= -90 and theta_deg < 90:  # right side
                 rot = theta_deg
             else:  # left side
                 rot = theta_deg - 180
+
             # Store values
             self.store_node_label_meta(x, y, tx, ty, rot)
 
@@ -703,7 +704,7 @@ class CircosPlot(BasePlot):
             self.node_label_aligns["has"].append("right")
 
         # Computes the text alignment for y
-        if self.node_label_layout == "rotation" or y == 0:
+        if self.node_label_layout == "rotate" or y == 0:
             self.node_label_aligns["vas"].append("center")
         elif y > 0:
             self.node_label_aligns["vas"].append("bottom")

--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -614,7 +614,7 @@ class CircosPlot(BasePlot):
 
             # Coordinates of text inside nodes
             if self.node_label_layout == "numbers":
-                radius_adjustment = 1.0 - (1.0 / radius)
+                radius_adjustment = self.plot_radius / radius
             else:
                 radius_adjustment = 1.02
             x, y = get_cartesian(r=radius * radius_adjustment, theta=theta)
@@ -641,7 +641,7 @@ class CircosPlot(BasePlot):
 
             # Computes the text rotation
             theta_deg = to_degrees(theta)
-            if theta_deg >= -90 and theta_deg < 90:  # right side
+            if theta_deg >= -90 and theta_deg <= 90:  # right side
                 rot = theta_deg
             else:  # left side
                 rot = theta_deg - 180
@@ -704,7 +704,7 @@ class CircosPlot(BasePlot):
             self.node_label_aligns["has"].append("right")
 
         # Computes the text alignment for y
-        if self.node_label_layout == "rotate" or y == 0:
+        if self.node_label_layout == "rotation" or y == 0:
             self.node_label_aligns["vas"].append("center")
         elif y > 0:
             self.node_label_aligns["vas"].append("bottom")


### PR DESCRIPTION
# Updates
- Now the node numbers are properly centered in the nodes when using ```node_label_layout="numbers"```
![Numbers-Labels](https://user-images.githubusercontent.com/12451195/74277457-6df47c80-4ccc-11ea-9961-c3e481802986.png)

- Node labels are properly aligned when using ```node_label_layout="rotation"```
![Rotation-Labels](https://user-images.githubusercontent.com/12451195/74277484-7cdb2f00-4ccc-11ea-93a1-2ed0cb893448.png)