### PR TITLE
Node sizes in Circos plots

### DIFF
--- a/nxviz/plots.py
+++ b/nxviz/plots.py
@@ -726,11 +726,12 @@ class CircosPlot(BasePlot):
         """
         Renders nodes to the figure.
         """
-        node_r = self.nodeprops["radius"]
+        
         lw = self.nodeprops["linewidth"]
         for i, node in enumerate(self.nodes):
             x = self.node_coords["x"][i]
             y = self.node_coords["y"][i]
+            node_r = self.node_sizes[i]
             color = self.node_colors[i]
             node_patch = patches.Circle(
                 (x, y), node_r, lw=lw, color=color, zorder=2


### PR DESCRIPTION
Changed the CircpsPlot.draw_nodes from the default nodeprop size to the node size from the data

This PR resolves issue #_______.

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Code Changes

If you are adding code changes, please ensure the following:

- [ ] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

# PR Description

Please describe the changes proposed in the pull request:

- Added node size option to CircosPlot

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
