### PR TITLE
Custom color mapping circos nodes and edges

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -19,3 +19,4 @@
 - Eduarda Centeno <eduardacenteno (at) hotmail.com>
 - Alireza Hosseini <alirezatheh (at) gmail.com>
 - Yashrajsinh Jadeja (@Yashrajsinh-Jadeja)
+- Kelvin Tuong <@zktuong>

--- a/nxviz/annotate.py
+++ b/nxviz/annotate.py
@@ -263,8 +263,12 @@ def colormapping(
         fig = plt.gcf()
         fig.colorbar(scalarmap)
     else:
-        labels = data.drop_duplicates().sort_values()
-        cfunc = encodings.color_func(data, palette)
+        if (palette is not None) and (isinstance(palette, dict)):
+            labels = pd.Series(list(palette.keys()))
+        else:
+            labels = pd.Series(data.unique())
+        cmap, _ = encodings.data_cmap(labels, palette)
+        cfunc = encodings.color_func(labels, palette)
         colors = labels.apply(cfunc)
         patchlist = []
         for color, label in zip(colors, labels):

--- a/nxviz/annotate.py
+++ b/nxviz/annotate.py
@@ -1,6 +1,6 @@
 """Annotation submodule."""
 from functools import partial, update_wrapper
-from typing import Dict, Hashable
+from typing import Dict, Hashable, Union, Optional, List
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -240,13 +240,18 @@ def matrix_block(
         ax.add_patch(patch)
 
 
-def colormapping(data: pd.Series, legend_kwargs: Dict = {}, ax=None):
+def colormapping(
+    data: pd.Series,
+    legend_kwargs: Dict = {},
+    ax=None,
+    palette: Optional[Union[Dict, List]] = None,
+):
     """Annotate node color mapping.
 
     If the color attribute is continuous, a colorbar will be added to the matplotlib figure.
     Otherwise, a legend will be added.
     """
-    cmap, data_family = encodings.data_cmap(data)
+    cmap, data_family = encodings.data_cmap(data, palette)
     if ax is None:
         ax = plt.gca()
     if data_family == "continuous":
@@ -259,7 +264,7 @@ def colormapping(data: pd.Series, legend_kwargs: Dict = {}, ax=None):
         fig.colorbar(scalarmap)
     else:
         labels = data.drop_duplicates().sort_values()
-        cfunc = encodings.color_func(data)
+        cfunc = encodings.color_func(data, palette)
         colors = labels.apply(cfunc)
         patchlist = []
         for color, label in zip(colors, labels):
@@ -280,11 +285,12 @@ def node_colormapping(
     color_by: Hashable,
     legend_kwargs: Dict = {"loc": "upper right", "bbox_to_anchor": (0.0, 1.0)},
     ax=None,
+    palette: Optional[Union[Dict, List]] = None,
 ):
     """Annotate node color mapping."""
     nt = utils.node_table(G)
     data = nt[color_by]
-    colormapping(data, legend_kwargs, ax)
+    colormapping(data, legend_kwargs, ax, palette)
 
 
 def edge_colormapping(
@@ -292,13 +298,14 @@ def edge_colormapping(
     color_by: Hashable,
     legend_kwargs: Dict = {"loc": "lower right", "bbox_to_anchor": (0.0, 0.0)},
     ax=None,
+    palette: Optional[Union[Dict, List]] = None,
 ):
     """Annotate edge color mapping."""
     if ax is None:
         ax = plt.gca()
     et = utils.edge_table(G)
     data = et[color_by]
-    colormapping(data, legend_kwargs, ax)
+    colormapping(data, legend_kwargs, ax, palette)
 
 
 def node_labels(G, layout_func, group_by, sort_by, fontdict={}, ax=None):

--- a/nxviz/api.py
+++ b/nxviz/api.py
@@ -2,7 +2,7 @@
 
 
 from functools import partial, update_wrapper
-from typing import Callable, Dict, Hashable
+from typing import Callable, Dict, Hashable, Optional, Union, List
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -31,6 +31,8 @@ def base(
     edge_enc_kwargs: Dict = {},
     node_layout_kwargs: Dict = {},
     edge_line_kwargs: Dict = {},
+    node_palette: Optional[Union[Dict, List]] = None,
+    edge_palette: Optional[Union[Dict, List]] = None,
 ):
     """High-level graph plotting function.
 
@@ -49,6 +51,10 @@ def base(
     - `node_size_by`: Node metadata attribute key to set node size.
     - `node_enc_kwargs`: Keyword arguments to set node visual encodings.
         TODO: Elaborate on what these arguments are.
+    - `node_palette`: Optional custom palette of colours for plotting categorical groupings
+        in a list/dictionary. Colours must be values `matplotlib.colors.ListedColormap`
+        can interpret. If a dictionary is provided, key and record corresponds to
+        category and colour respectively.
 
     ### Edges
 
@@ -60,6 +66,7 @@ def base(
     - `edge_lw_by`: Edge metdata attribute key to set edge line width.
     - `edge_alpha_by`: Edge metdata attribute key to set edge transparency.
     - `edge_enc_kwargs`: Keyword arguments to set edge visual encodings.
+    - `edge_palette`: Same as node_palette but for edges.
         TODO: Elaborate on what these arguments are.
     """
     pos = node_layout_func(
@@ -71,6 +78,7 @@ def base(
         alpha_by=node_alpha_by,
         encodings_kwargs=node_enc_kwargs,
         layout_kwargs=node_layout_kwargs,
+        palette=node_palette,
     )
     edge_line_func(
         G,
@@ -80,6 +88,7 @@ def base(
         lw_by=edge_lw_by,
         alpha_by=edge_alpha_by,
         encodings_kwargs=edge_enc_kwargs,
+        palette=edge_palette,
     )
 
     despine()
@@ -146,6 +155,8 @@ def base_cloned(
     node_layout_kwargs: Dict = {},
     edge_line_kwargs: Dict = {},
     cloned_node_layout_kwargs: Dict = {},
+    node_palette: Optional[Union[Dict, List]] = None,
+    edge_palette: Optional[Union[Dict, List]] = None,
 ):
     """High-level graph plotting function.
 
@@ -164,6 +175,10 @@ def base_cloned(
     - `node_size_by`: Node metadata attribute key to set node size.
     - `node_enc_kwargs`: Keyword arguments to set node visual encodings.
         TODO: Elaborate on what these arguments are.
+    - `node_palette`: Optional custom palette of colours for plotting categorical groupings
+        in a list/dictionary. Colours must be values `matplotlib.colors.ListedColormap`
+        can interpret. If a dictionary is provided, key and record corresponds to
+        category and colour respectively.
 
     ### Edges
 
@@ -175,7 +190,7 @@ def base_cloned(
     - `edge_lw_by`: Edge metdata attribute key to set edge line width.
     - `edge_alpha_by`: Edge metdata attribute key to set edge transparency.
     - `edge_enc_kwargs`: Keyword arguments to set edge visual encodings.
-        TODO: Elaborate on what these arguments are.
+    - `edge_palette`: Same as node_palette but for edges.
     """
     pos = node_layout_func(
         G,
@@ -186,6 +201,7 @@ def base_cloned(
         alpha_by=node_alpha_by,
         encodings_kwargs=node_enc_kwargs,
         layout_kwargs=node_layout_kwargs,
+        palette=node_palette,
     )
     pos_cloned = node_layout_func(
         G,
@@ -196,6 +212,7 @@ def base_cloned(
         alpha_by=node_alpha_by,
         encodings_kwargs=node_enc_kwargs,
         layout_kwargs=cloned_node_layout_kwargs,
+        palette=node_palette,
     )
     edge_line_func(
         G,
@@ -206,6 +223,7 @@ def base_cloned(
         lw_by=edge_lw_by,
         alpha_by=edge_alpha_by,
         encodings_kwargs=edge_enc_kwargs,
+        palette=edge_palette,
         **edge_line_kwargs,
     )
 
@@ -253,6 +271,8 @@ class BasePlot:
         edge_alpha: Hashable = None,
         edge_width: Hashable = None,
         edgeprops: Dict = None,
+        node_palette: Optional[Union[Dict, List]] = None,
+        edge_palette: Optional[Union[Dict, List]] = None,
     ):
         """Instantiate a plot.
 
@@ -269,6 +289,11 @@ class BasePlot:
         - `edge_alpha`: The edge attribute on which to specify the transparency of edges.
         - `edge_width`: The edge attribute on which to specify the width of edges.
         - `edgeprops`: A `matplotlib-compatible `props` dictionary.
+        - `node_palette`: Optional custom palette of colours for plotting categorical groupings
+        in a list/dictionary. Colours must be values `matplotlib.colors.ListedColormap`
+        can interpret. If a dictionary is provided, key and record corresponds to
+        category and colour respectively.
+        - `edge_palette`: Same as node_palette but for edges.
         """
         import warnings
 
@@ -300,6 +325,8 @@ functional_api_names = [
     "edge_alpha_by",
     "edge_lw_by",
     "edge_enc_kwargs",
+    "node_palette",
+    "edge_palette",
 ]
 
 object_api_names = [
@@ -313,6 +340,8 @@ object_api_names = [
     "edge_alpha",
     "edge_width",
     "edgeprops",
+    "node_palette",
+    "edge_palette",
 ]
 
 functional_to_object = dict(zip(functional_api_names, object_api_names))

--- a/nxviz/edges.py
+++ b/nxviz/edges.py
@@ -50,9 +50,7 @@ def edge_colors(
     if color_by in ("source_node_color", "target_node_color"):
         edge_select_by = color_by.split("_")[0]
         return encodings.data_color(
-            et[edge_select_by].apply(nt[node_color_by].get),
-            nt[node_color_by],
-            palette
+            et[edge_select_by].apply(nt[node_color_by].get), nt[node_color_by], palette
         )
     elif color_by:
         return encodings.data_color(et[color_by], et[color_by], palette)

--- a/nxviz/edges.py
+++ b/nxviz/edges.py
@@ -7,7 +7,7 @@ Firstly,
 
 from copy import deepcopy
 from functools import partial, update_wrapper
-from typing import Callable, Dict, Hashable, Tuple, Optional
+from typing import Callable, Dict, Hashable, Tuple, Optional, Union, List
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -44,6 +44,7 @@ def edge_colors(
     nt: pd.DataFrame,
     color_by: Hashable,
     node_color_by: Hashable,
+    palette: Optional[Union[Dict, List]] = None,
 ):
     """Default edge line color function."""
     if color_by in ("source_node_color", "target_node_color"):
@@ -51,9 +52,10 @@ def edge_colors(
         return encodings.data_color(
             et[edge_select_by].apply(nt[node_color_by].get),
             nt[node_color_by],
+            palette
         )
     elif color_by:
-        return encodings.data_color(et[color_by], et[color_by])
+        return encodings.data_color(et[color_by], et[color_by], palette)
     return pd.Series(["black"] * len(et), name="color_by")
 
 
@@ -85,6 +87,7 @@ def draw(
     alpha_by: Hashable = None,
     ax=None,
     encodings_kwargs: Dict = {},
+    palette: Optional[Union[Dict, List]] = None,
     **linefunc_kwargs,
 ):
     """Draw edges to matplotlib axes.
@@ -108,6 +111,10 @@ def draw(
     - `ax`: Matplotlib axes object to plot onto.
     - `encodings_kwargs`: A dictionary of kwargs
         to determine the visual properties of the edge.
+    - `palette`: Optional custom palette of colours for plotting categorical groupings
+        in a list/dictionary. Colours must be values `matplotlib.colors.ListedColormap`
+        can interpret. If a dictionary is provided, key and record corresponds to
+        category and colour respectively.
     - `linefunc_kwargs`: All other keyword arguments passed in
         will be passed onto the appropriate linefunc.
 
@@ -135,7 +142,7 @@ def draw(
     if ax is None:
         ax = plt.gca()
     validate_color_by(G, color_by, node_color_by)
-    edge_color = edge_colors(et, nt, color_by, node_color_by)
+    edge_color = edge_colors(et, nt, color_by, node_color_by, palette)
     encodings_kwargs = deepcopy(encodings_kwargs)
     lw = line_width(et, lw_by) * encodings_kwargs.pop("lw_scale", 1.0)
 

--- a/nxviz/encodings.py
+++ b/nxviz/encodings.py
@@ -118,7 +118,9 @@ def color_func(
     func = discrete_color_func
     if data_family in ["continuous", "ordinal"]:
         func = continuous_color_func
-    return partial(func, cmap=cmap, data=data, palette=palette)
+        return partial(func, cmap=cmap, data=data)
+    else:
+        return partial(func, cmap=cmap, data=data, palette=palette)
 
 
 def data_color(

--- a/nxviz/nodes.py
+++ b/nxviz/nodes.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from functools import partial, update_wrapper
-from typing import Callable, Dict, Hashable, Optional, Tuple
+from typing import Callable, Dict, Hashable, Optional, Tuple, Union, List
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -15,10 +15,10 @@ from nxviz.utils import node_table
 from nxviz.plots import rescale, rescale_arc, rescale_square
 
 
-def node_colors(nt: pd.DataFrame, color_by: Hashable):
+def node_colors(nt: pd.DataFrame, color_by: Hashable, palette: Optional[Union[Dict, List]] = None):
     """Return pandas Series of node colors."""
     if color_by:
-        return encodings.data_color(nt[color_by], nt[color_by])
+        return encodings.data_color(nt[color_by], nt[color_by], palette)
     return pd.Series(["blue"] * len(nt), name="color_by", index=nt.index)
 
 
@@ -67,6 +67,7 @@ def draw(
     encodings_kwargs: Dict = {},
     rescale_func=rescale,
     ax=None,
+    palette: Optional[Union[Dict, List]] = None,
 ):
     """Draw nodes to matplotlib axes.
 
@@ -83,8 +84,10 @@ def draw(
         to the appropriate layout function.
     - `encodings_kwargs`: A dictionary of kwargs
         to determine the visual properties of the node.
-    - `linefunc_kwargs`: All other keyword arguments passed in
-        will be passed onto the appropriate linefunc.
+    - `palette`: Optional custom palette of colours for plotting categorical groupings
+        in a list/dictionary. Colours must be values `matplotlib.colors.ListedColormap`
+        can interpret. If a dictionary is provided, key and record corresponds to
+        category and colour respectively.
 
     Special keyword arguments for `encodings_kwargs` include:
 
@@ -109,7 +112,7 @@ def draw(
         ax = plt.gca()
     nt = node_table(G)
     pos = layout_func(nt, group_by, sort_by, **layout_kwargs)
-    node_color = node_colors(nt, color_by)
+    node_color = node_colors(nt, color_by, palette)
 
     encodings_kwargs = deepcopy(encodings_kwargs)
     alpha_bounds = encodings_kwargs.pop("alpha_bounds", None)

--- a/nxviz/nodes.py
+++ b/nxviz/nodes.py
@@ -15,7 +15,9 @@ from nxviz.utils import node_table
 from nxviz.plots import rescale, rescale_arc, rescale_square
 
 
-def node_colors(nt: pd.DataFrame, color_by: Hashable, palette: Optional[Union[Dict, List]] = None):
+def node_colors(
+    nt: pd.DataFrame, color_by: Hashable, palette: Optional[Union[Dict, List]] = None
+):
     """Return pandas Series of node colors."""
     if color_by:
         return encodings.data_color(nt[color_by], nt[color_by], palette)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,2 @@
 """Pytest configuration."""
-from .fixtures.graphs import dummyG, geoG, manygroupG, smallG
+from .fixtures.graphs import dummyG, geoG, manygroupG, smallG, tab20

--- a/tests/fixtures/graphs.py
+++ b/tests/fixtures/graphs.py
@@ -69,6 +69,9 @@ def manygroupG():
     for n in G.nodes():
         G.nodes[n]["group"] = next(many_categorical)
 
+    for u, v in G.edges():
+        G.edges[u, v]["edge_group"] = next(categorical)
+
     return G
 
 
@@ -77,3 +80,32 @@ def smallG():
     """Generate a small graph with 10 nodes."""
     G = nx.erdos_renyi_graph(n=10, p=0.15)
     return G
+
+
+@pytest.fixture
+def tab20():
+    """
+    Return a tableau20 palette
+    """
+    return [
+        "#1f77b4",
+        "#ff7f0e",
+        "#279e68",
+        "#d62728",
+        "#aa40fc",
+        "#8c564b",
+        "#e377c2",
+        "#b5bd61",
+        "#17becf",
+        "#aec7e8",
+        "#ffbb78",
+        "#98df8a",
+        "#ff9896",
+        "#c5b0d5",
+        "#c49c94",
+        "#f7b6d2",
+        "#dbdb8d",
+        "#9edae5",
+        "#ad494a",
+        "#8c6d31",
+    ]

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -54,6 +54,43 @@ def test_node_colormapping(dummyG):
     annotate.node_colormapping(dummyG, color_by="group")
 
 
+@pytest.mark.usefixtures("manygroupG", "tab20")
+def test_node_colormapping_node_palette(manygroupG, tab20):
+    """Execution test for node_colormapping with many groupings."""
+    with pytest.raises(ValueError):
+        ax = nv.circos(manygroupG, group_by="group", node_color_by="group")
+        annotate.node_colormapping(manygroupG, color_by="group")
+
+    ax = nv.circos(
+        manygroupG, group_by="group", node_color_by="group", node_palette=tab20
+    )
+    annotate.node_colormapping(manygroupG, color_by="group", palette=tab20)
+    paldict = dict(
+        zip(
+            list(set([manygroupG.nodes[n]["group"] for n in manygroupG.nodes()])), tab20
+        )
+    )
+    ax = nv.circos(
+        manygroupG, group_by="group", node_color_by="group", node_palette=paldict
+    )
+    annotate.node_colormapping(manygroupG, color_by="group", palette=paldict)
+
+
+@pytest.mark.usefixtures("manygroupG", "tab20")
+def test_node_colormapping_edge_palette(manygroupG, tab20):
+    """Execution test for node_colormapping with many groupings."""
+    ax = nv.circos(
+        manygroupG,
+        group_by="group",
+        node_color_by="group",
+        edge_color_by="edge_group",
+        node_palette=tab20,
+        edge_palette=tab20,
+    )
+    annotate.node_colormapping(manygroupG, color_by="group", palette=tab20)
+    annotate.edge_colormapping(manygroupG, color_by="edge_group", palette=tab20)
+
+
 @pytest.mark.usefixtures("dummyG")
 def test_edge_colormapping(dummyG):
     """Execution test for edge_colormapping."""


### PR DESCRIPTION
This PR resolves issue #682 and #572.

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Code Changes

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

## Documentation Changes

If you are adding documentation changes, please ensure the following:

- [ ] Build the docs locally.
- [ ] View the docs to check that it renders correctly.

# PR Description

Please describe the changes proposed in the pull request:

Hi, first just want to express my gratitude for making this fantastic package!

In this PR, I've just simply added `node_palette` and `edge_palette` kwargs  with the main idea to allow `circos` to accept either a list or dictionary of custom color palettes for colouring categories. `annotate.node_colormapping` and `annotate.edge_colormapping` also received a similar treatment but accepts `palette` as the kwarg.

This gets around the issue of only limited to 12 colours and allow for custom color selection. I've inserted the kwargs into the functions in `.api` but I've only tried this on `circos` so i'm not sure if it impacts on the rest of the package.

Minimal example to illustrate the outcome:
```python
import networkx as nx
import nxviz as nv
import matplotlib.pyplot as plt
from itertools import cycle
from nxviz import annotate

# 14 categories
categories = [
    "sun",
    "moon",
    "stars",
    "cloud",
    "wheel",
    "box",
    "plant",
    "chair",
    "slippers",
    "tablet",
    "laptop",
    "dishwasher",
    "bicycle",
    "piano",
    "laptop",
]

# 20 colors - providing an uneven list on purpose
palette = [
    "#1f77b4",
    "#ff7f0e",
    "#279e68",
    "#d62728",
    "#aa40fc",
    "#8c564b",
    "#e377c2",
    "#b5bd61",
    "#17becf",
    "#aec7e8",
    "#ffbb78",
    "#98df8a",
    "#ff9896",
    "#c5b0d5",
    "#c49c94",
    "#f7b6d2",
    "#dbdb8d",
    "#9edae5",
    "#ad494a",
    "#8c6d31",
]

categorical = cycle(categories[0:4]) # max 4 distinct categories
categories[0:4]
# ['sun', 'moon', 'stars', 'cloud']
many_categorical = cycle(categories) # up to 14

n = 71
p = 0.01
G = nx.erdos_renyi_graph(n=n, p=p)

for n in G.nodes():
    G.nodes[n]["group1"] = next(categorical)
    G.nodes[n]["group2"] = next(many_categorical) # up to 14
for u, v in G.edges():
    G.edges[u, v]["edge_group1"] = next(categorical)
    G.edges[u, v]["edge_group2"] = next(many_categorical) # up to 14
    G.edges[u, v]["thickness"] = 3  # just to be able see the edge colours later
```

Current default behavior as it is right now (before/after this PR) i.e. don't specify the palette options:
```python
nv.circos(G, group_by="group1", node_color_by="group1")
annotate.node_colormapping(G, color_by="group1")
```
![image](https://user-images.githubusercontent.com/26215587/174125677-5cfd2868-e116-494d-b8e6-20b367669473.png)

when there's >12 categories, just modified the error message to ask for people to provide their own palette.
```python
nv.circos(G, group_by="group2", node_color_by="group2")
```
![image](https://user-images.githubusercontent.com/26215587/174125727-ce3a78bc-2b13-4a7f-9df9-0564888b6a5d.png)

this PR's proposed changes:
```python
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=palette[:4]) # specify 4 colors for 4 groups
```
![image](https://user-images.githubusercontent.com/26215587/174125753-6c39765f-c8e7-4d1b-a53c-3b173e9d1bfe.png)

now with more than 12 categories (14), and a long color palette (20 colors)
```python
nv.circos(G, group_by="group2", node_color_by="group2", node_palette=palette)
```
![image](https://user-images.githubusercontent.com/26215587/174125812-74a3ac25-6b1d-477b-beff-c40f38fc4c9c.png)

same as above but limit to 7 colors - colors start to cycle if palette is provided as a list.
```python
nv.circos(G, group_by="group2", node_color_by="group2", node_palette=palette[:7])
```
![image](https://user-images.githubusercontent.com/26215587/174126581-1f71ba1c-b937-4f13-9f0f-0344a076ceac.png)

if provided as a dictionary: 
```python
pal = {'moon':'red', 'stars':'yellow', 'sun':'black', 'cloud':'blue'}
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=pal)
annotate.node_colormapping(G, color_by="group1", palette=pal)
```
![image](https://user-images.githubusercontent.com/26215587/174126079-34e60b60-c1fc-444e-a6e9-58cd5b5ec535.png)

order of keys don't matter
```python
pal = {'moon':'red', 'cloud':'pink', 'stars':'yellow', 'sun':'black'}
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=pal)
annotate.node_colormapping(G, color_by="group1", palette=pal)
```
![image](https://user-images.githubusercontent.com/26215587/174126096-d74636c9-ce7e-4ecf-a2c7-e61e81c9c92a.png)


can mix colors/hex codes
```python
pal = ['pink', '#1f77B4', 'green', '#ff7f0e']
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=pal)
annotate.node_colormapping(G, color_by="group1", palette=pal)
```
![image](https://user-images.githubusercontent.com/26215587/174126244-6ad3591c-4335-4ac7-a07f-d59bae021905.png)

swapping of order of colors in a list matters.  But the plot should reflect this correctly - if you look up at the dictionary examples, the same order is preserved.
```python
pal = ['pink', '#1f77B4', '#ff7f0e', 'green'] # swapped the order of the last two colours
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=pal)
annotate.node_colormapping(G, color_by="group1", palette=pal)
```
![image](https://user-images.githubusercontent.com/26215587/174126398-cc5db0fe-0c01-48ff-b9a4-fb0ea3801bf6.png)


Can be used on edges as well:
```python
nv.circos(G, 
          group_by="group2", 
          node_color_by="group2", 
          edge_color_by = 'edge_group1', 
          node_palette=palette, 
          edge_palette = palette,
          edge_lw_by = 'thickness',
         )
annotate.node_colormapping(G, color_by="group2", palette=palette)
annotate.edge_colormapping(G, color_by="edge_group1", palette=palette)
```
![image](https://user-images.githubusercontent.com/26215587/174127002-76c801cf-d32b-489d-b92f-2ae225d5e463.png)

As a sanity check, just to ensure that the color/order is respected you can see in this small graph where only 2 categories will be repeated twice (sun and moon), the color mapping remains consistent:

default i.e. palette not provided
```python
n = 6
p = .01
G = nx.erdos_renyi_graph(n=n, p=p)
assignments = []
for n in G.nodes():
    G.nodes[n]["group1"] = next(categorical)
    assignments.append(G.nodes[n]["group1"])
    G.nodes[n]["group2"] = next(many_categorical)
assignments
# ['sun', 'moon', 'stars', 'cloud', 'sun', 'moon']
nv.circos(G, group_by="group1", node_color_by="group1")
annotate.node_colormapping(G, color_by="group1")
```
![image](https://user-images.githubusercontent.com/26215587/174129146-6a7db7c2-1118-4dc7-985a-414463ae0ffc.png)

palette provided as a list. Because sun was added first (it was added sequentially as 'sun', 'moon', 'stars', 'cloud', 'sun', 'moon'), it should be pink. cloud is the last unique entry, so should be green.
```python
pal = ['pink', '#1f77B4', '#ff7f0e', 'green']
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=pal)
annotate.node_colormapping(G, color_by="group1", palette=pal)
```
![image](https://user-images.githubusercontent.com/26215587/174129249-194a2b07-54fd-4010-b9fe-0c1f7ed19ed1.png)

palette is provided as a dictionary.
```python
pal = {'moon':'red', 'stars':'yellow', 'sun':'black', 'cloud':'blue'}
nv.circos(G, group_by="group1", node_color_by="group1", node_palette=pal)
annotate.node_colormapping(G, color_by="group1", palette=pal)
```
![image](https://user-images.githubusercontent.com/26215587/174129320-cd746e7a-5e8b-4c18-b264-cb6dad495ae9.png)

let me know what you think!

Cheers,
Kelvin

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
