### PR TITLE
build(build-system)🔧!: Switch build system from setuptools to hatchling

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5950,7 +5950,7 @@ packages:
 - pypi: .
   name: nxviz
   version: 0.7.5
-  sha256: da0ddda80d00c3cf30990a7dfeac754113a6dd902477289cc8b0e8e346531f46
+  sha256: e478ac1955dce8a7b46f08ec8c0254e114e0de8bec3cefdd847e8bab49ef313a
   requires_dist:
   - setuptools
   - matplotlib>=3.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "pandas>=1.2.0",
   "seaborn>=0.11.1",
 ]
-license = "MIT"
 readme = "README.md"
 keywords = ["nxviz", "networkx", "visualization", "graph"]
 classifiers = [
@@ -113,10 +112,10 @@ test = "pytest"
 docs = "mkdocs build"
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.18.0"]  # Use a version that supports metadata 2.4
+build-backend = "hatchling.build"
 
-[tool.setuptools]
+[tool.hatch.build]
 packages = ["nxviz"]
 
 [tool.tox]


### PR DESCRIPTION
- Updated the build-system requirements and backend to use hatchling.
- Removed the license field from the project metadata.