### PR TITLE
fix(plotly): matrix plot y-axis nodes + remove deprecation warning + spruce up notebook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,21 @@ Do not add comments unless explicitly asked. Code should be self-documenting thr
 - Optional deps (plotly) go in `[project.optional-dependencies]` as extras
 - pixi features handle dev/test/doc tooling
 
+### Marimo pair programming
+
+When using marimo-pair to edit a notebook, you **must** guarantee zero errors across all cells after every batch of edits. After creating, editing, or moving cells, always check for errors:
+
+```python
+async with cm.get_context() as ctx:
+    for name, cell in ctx.cells.items():
+        if cell.errors or "error" in str(cell.status):
+            print(f"{name}: {cell.errors}")
+```
+
+Fix any errors before proceeding. Common pitfalls:
+- **Multiply-defined names**: Only one cell may define a variable (e.g., `import marimo as mo`). Other cells that need it must reference it, not re-import it.
+- **Use `skip_validation=True`** on `cm.get_context()` only when editing cells with multiply-defined names to fix them — not as a way to ignore the problem.
+
 ### Marimo notebooks (PEP 723 inline script metadata)
 
 All marimo notebooks in `docs/` use PEP 723 inline script metadata with `[tool.uv.sources]` for local path dependencies. The format is:

--- a/docs/examples/plotly-backend.py
+++ b/docs/examples/plotly-backend.py
@@ -5,6 +5,26 @@ app = marimo.App(width="medium")
 
 
 @app.cell(hide_code=True)
+def intro_md():
+    import marimo as mo
+
+    mo.md(
+        "# Plotly Backend for nxviz\n\nThis notebook demonstrates the **Plotly backend** for nxviz, providing interactive network visualizations.\n\nWe will build a random graph with categorical and continuous node/edge attributes, then render it using both matplotlib and Plotly backends for comparison."
+    )
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def md_build(mo):
+    mo.md("""
+    ## Build the Graph
+
+    We construct an Erdos-Renyi random graph with 71 nodes and edge probability 0.1. Each node gets a categorical `group` attribute (sun/moon/stars) and an ordinal `value`. Edges receive a continuous `edge_value`.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
 def build_graph():
     from itertools import cycle
 
@@ -29,6 +49,16 @@ def build_graph():
 
 
 @app.cell(hide_code=True)
+def md_mpl(mo):
+    mo.md("""
+    ## Matplotlib Circos (Reference)
+
+    The familiar matplotlib-based circos plot, shown here for comparison with the Plotly versions below.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
 def matplotlib_circos(G, nv):
     ax = nv.circos(G, group_by="group", sort_by="value", node_color_by="group")
     ax
@@ -36,29 +66,93 @@ def matplotlib_circos(G, nv):
 
 
 @app.cell(hide_code=True)
+def md_plotly_circos(mo):
+    mo.md("""
+    ## Plotly Circos
+
+    The same circos plot rendered with the **Plotly backend**. Try hovering over nodes and edges, and use the Plotly toolbar to zoom and pan.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
 def plotly_circos(G, nv):
-    fig_circos = nv.circos(G, group_by="group", sort_by="value", node_color_by="group", backend="plotly")
+    fig_circos = nv.circos(
+        G,
+        group_by="group",
+        sort_by="value",
+        node_color_by="group",
+        backend="plotly",
+    )
     fig_circos
     return
 
 
 @app.cell(hide_code=True)
+def md_plotly_arc(mo):
+    mo.md("""
+    ## Plotly Arc
+
+    An arc diagram rendered with Plotly. Arc plots are useful for visualizing connectivity patterns along a single axis.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
 def plotly_arc(G, nv):
-    fig_arc = nv.arc(G, group_by="group", sort_by="value", node_color_by="group", backend="plotly")
+    fig_arc = nv.arc(
+        G,
+        group_by="group",
+        sort_by="value",
+        node_color_by="group",
+        backend="plotly",
+    )
     fig_arc
     return
 
 
 @app.cell(hide_code=True)
+def md_plotly_hive(mo):
+    mo.md("""
+    ## Plotly Hive
+
+    A hive plot rendered with Plotly. Hive plots arrange nodes along radial axes grouped by category, making structural patterns more apparent.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
 def plotly_hive(G, nv):
-    fig_hive = nv.hive(G, group_by="group", sort_by="value", node_color_by="group", backend="plotly")
+    fig_hive = nv.hive(
+        G,
+        group_by="group",
+        sort_by="value",
+        node_color_by="group",
+        backend="plotly",
+    )
     fig_hive
     return
 
 
 @app.cell(hide_code=True)
+def md_plotly_matrix(mo):
+    mo.md("""
+    ## Plotly Matrix
+
+    A matrix plot rendered with Plotly. Matrix plots reveal adjacency structure at a glance, with nodes sorted by group and value.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
 def plotly_matrix(G, nv):
-    fig_matrix = nv.matrix(G, group_by="group", sort_by="value", node_color_by="group", backend="plotly")
+    fig_matrix = nv.matrix(
+        G,
+        group_by="group",
+        sort_by="value",
+        node_color_by="group",
+        backend="plotly",
+    )
     fig_matrix
     return
 

--- a/nxviz/__init__.py
+++ b/nxviz/__init__.py
@@ -1,6 +1,5 @@
 """Top-level nxviz API."""
 
-import warnings
 from importlib.metadata import version
 
 from .api import (
@@ -29,17 +28,3 @@ __all__ = [
     "CircosPlot",
     "version",
 ]
-
-warnings.warn(
-    """
-nxviz has a new API! Version 0.7.4 onwards, the old class-based API is being
-deprecated in favour of a new API focused on advancing a grammar of network
-graphics. If your plotting code depends on the old API, please consider
-pinning nxviz at version 0.7.4, as the new API will break your old code.
-
-To check out the new API, please head over to the docs at
-https://ericmjl.github.io/nxviz/ to learn more. We hope you enjoy using it!
-
-(This deprecation message will go away in version 1.0.)
-"""
-)

--- a/nxviz/api.py
+++ b/nxviz/api.py
@@ -77,6 +77,11 @@ def backend_plot(
             nt, group_by, sort_by, **cloned_node_layout_kwargs
         )
 
+    if pos_cloned is not None:
+        backend_obj.draw_nodes(
+            axes, nt, pos_cloned, node_color, alpha, size, encodings_kwargs=enc_kw
+        )
+
     if line_type == "circos":
         path_coords = paths.circos_coords(et, pos)
     elif line_type == "line":


### PR DESCRIPTION
## Changes

- **Fix Plotly matrix plots**: nodes were only drawn on the x-axis. Now also drawn on the y-axis using `pos_cloned`.
- **Remove deprecated API warning**: the `warnings.warn` in `__init__.py` is no longer needed.
- **Spruce up plotly-backend notebook**: add markdown cells around each code cell for context.