### PR TITLE
Port from deprecated cm.get_cmap

### DIFF
--- a/docs/api/low-level-api.py
+++ b/docs/api/low-level-api.py
@@ -204,8 +204,8 @@ def _(np):
 
     def value_colormap(data: pd.Series):
         """Value colormap."""
-        norm = plt.cm.Normalize(vmin=data.min(), vmax=data.max())
-        cmap = plt.cm.get_cmap("viridis")
+        norm = plt.Normalize(vmin=data.min(), vmax=data.max())
+        cmap = plt.get_cmap("viridis")
         return data.apply(lambda x: cmap(norm(x)))
 
 

--- a/nxviz/encodings.py
+++ b/nxviz/encodings.py
@@ -6,8 +6,8 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from matplotlib.cm import get_cmap
 from matplotlib.colors import BoundaryNorm, ListedColormap, Normalize
+from matplotlib.pyplot import get_cmap
 from palettable.colorbrewer import qualitative
 
 from nxviz.utils import infer_data_family


### PR DESCRIPTION
# PR Checklist

## Code Changes

If you are adding code changes, please ensure the following:

- [X] Ensure that you have added tests.
- [X] Run all tests (`$ pytest .`) locally on your machine.
    - [X] Check to ensure that test coverage covers the lines of code that you have added.
    - [X] Ensure that all tests pass.

# PR Description

Please describe the changes proposed in the pull request:

- matplotlib 3.11 removed `matplotlib.cm.get_cmap` (after being deprecated since 3.7?). See https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.11.0.html#matplotlib-cm-get-cmap
- Ported to use `matplotlib.pyplot.get_cmap` instead

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
